### PR TITLE
Get children taxons ordered 

### DIFF
--- a/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/Resources/config/doctrine/model/Taxon.orm.xml
@@ -50,8 +50,8 @@
                 <cascade-all />
             </cascade>
             <order-by>
-            <order-by-field name="left" direction="ASC" />
-        </order-by>
+                <order-by-field name="left" direction="ASC" />
+            </order-by>
         </one-to-many>
 
         <order-by>


### PR DESCRIPTION
Hi,  I like and use  this bundle but I've found an couple of problems about the Taxon entity mapping
-If we don`t set order-by attribute in children relation, we get children ordered by id not by left.
-The right order is "left ASC".

According with https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/tree.md#xml-mapping-example.

Thanks for your time!
