### PR TITLE
Update macros.html.twig

### DIFF
--- a/Resources/views/Taxon/macros.html.twig
+++ b/Resources/views/Taxon/macros.html.twig
@@ -25,6 +25,8 @@
 
 {% macro tree(taxonomy, taxons) %}
 
+{% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %}
+
 {% for taxon in taxons %}
 <tr>
     <td>


### PR DESCRIPTION
Added {% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %} to macro tree. 

if i use this bundle. i will get the error that the variable buttons does not exists on line 38. After i added the import to the macro tree this problem was fixed. So I think that a import has to be at Macro level.
